### PR TITLE
[Bugfix] doing nil check before calling combined-modifier-flags

### DIFF
--- a/src/dots/extract.cljs
+++ b/src/dots/extract.cljs
@@ -237,7 +237,9 @@
       (ts/display-parts-to-string parts))))
 
 (defn- modifier-flags [sym]
-  (ts/combined-modifier-flags (symbol/value-declaration sym)))
+  (let [value-declaration (symbol/value-declaration sym)]
+    (when (some? value-declaration)
+      (ts/combined-modifier-flags value-declaration))))
 
 (declare extract-symbol)
 


### PR DESCRIPTION
When I try dots, I find I got some errors for some modules like **http** and **pixi.js**. The errors look like this
```
~/dots/node_modules/typescript/lib/typescript.js:26735
    return node.kind === 208 /* BindingElement */;
                ^
TypeError: Cannot read properties of undefined (reading 'kind')
    at isBindingElement (~/dots/node_modules/typescript/lib/typescript.js:26735:17)
    at getCombinedFlags (~/dots/node_modules/typescript/lib/typescript.js:11582:9)
    at Object.getCombinedModifierFlags (~/dots/node_modules/typescript/lib/typescript.js:11599:12)
    at h9 (~/dots/dist/dots.js:1707:102)
    at a9 (~/dots/dist/dots.js:1710:435)
    at ~e/dots/dist/dots.js:1703:314
    at xf (~/dots/dist/dots.js:135:276)
    at Yb.l (~/dots/dist/dots.js:189:237)
    at~/dots/dist/dots.js:1703:278
    at Ll.l (~/dots/dist/dots.js:419:115)
```
After digging the issue in the repl mode, I find that **dots** will check if there is the modifier-flags, which can throw the exception when value-declaration is nil.
`(has? (modifier-flags sym) modifier-flags/readonly) (assoc :const? true))))`

In this fix, I simply add a `some?` check before calling the `ts/combined-modifier-flags` to avoid triggering the exception.

The result becomes like this

```
% node ./dist/dots.js http
Warning: No adapt-trait implementation for :type-alias OutgoingHttpHeader
Warning: No adapt-trait implementation for :type-alias RequestListener
```

I am very new to clojurescript, and have no knowledge about typescript ast. Therefore, this fix may change the expected behavior. Please don't hesitate to share your advice. 